### PR TITLE
Adding PR review

### DIFF
--- a/models/staging/stg_customer_order_summary_PR.sql
+++ b/models/staging/stg_customer_order_summary_PR.sql
@@ -1,0 +1,68 @@
+WITH
+
+raw_customers AS (
+   SELECT
+       id AS customer_id,
+       first_name,
+       last_name,
+       email_address,
+       phone_number,
+       created_at AS signup_date
+   FROM raw.database.orders
+   -- Select all customers regardless of status or signup date for simplicity
+),
+
+
+-- Get order data
+raw_orders AS (
+   SELECT
+       o.id AS order_id,
+       o.customer_id,
+       o.order_date,
+       o.order_status,
+       o.total_amount
+   FROM {{ source('raw', 'orders') }} o
+   WHERE o.order_status IN ('completed', 'shipped')
+),
+
+
+order_totals AS (
+   SELECT
+       raw_orders.customer_id,
+       COUNT(raw_orders.order_id) AS total_orders,
+       SUM(raw_orders.total_amount) AS total_spent,
+       MIN(raw_orders.order_date) AS first_order_date,
+       MAX(raw_orders.order_date) AS last_order_date
+   FROM raw_orders
+   GROUP BY raw_orders.customer_id
+),
+
+
+customer_data AS (
+   SELECT
+       raw_customers.customer_id,
+       CONCAT(raw_customers.first_name, ' ', raw_customers.last_name) AS full_name,
+       raw_customers.email_address,
+       raw_customers.phone_number,
+       order_totals.total_orders,
+       order_totals.total_spent,
+       order_totals.first_order_date,
+       order_totals.last_order_date
+   FROM raw_customers
+   LEFT JOIN order_totals ON raw_customers.customer_id = order_totals.customer_id
+)
+
+
+SELECT
+   customer_data.customer_id,
+   customer_data.full_name,
+   customer_data.email_address,
+   customer_data.phone_number,
+   customer_data.total_orders,
+   customer_data.total_spent,
+   CASE
+       WHEN customer_data.total_spent > 500 THEN 'Premium'
+       ELSE 'Standard'
+   END AS customer_type
+FROM customer_data
+ORDER BY customer_data.total_spent DESC;


### PR DESCRIPTION
**General Observations**
This query provides a useful customer-centric summary combining basic customer attributes with order metrics. However, the current implementation leans more toward an ad hoc reporting query than a well-structured dbt staging model. The logic could be better modularized, cleaned, and layered to align with dbt principles of maintainability, reusability, and DAG clarity.

Specific Feedback
1. Model Naming and Layering

- Despite being named stg_, the model performs transformations that would be more appropriate in the intermediate/ or even marts/ layer (e.g., aggregating total_spent and deriving customer_type).
- Consider breaking this out into separate models:
  - stg_customers
  - stg_orders
  - int_customer_order_summary
  - dim_customer (for enriched attributes like customer type)

2. Inline CTEs vs Modular Models

- Each major CTE (raw_customers, raw_orders, order_totals) should ideally be its own staging model or ref() call to promote reuse and clarity.
- Avoid duplicating logic in CTEs across models; instead, reference cleaned staging models with {{ ref() }}.

3. Use of Sources

- The raw_customers CTE uses FROM raw.database.orders, which is not consistent with dbt source definitions. This should use {{ source('raw', 'customers') }} (or whatever is defined in sources.yml) for source freshness, lineage, and documentation.

4. Missing/Unused Fields

- Fields like first_order_date and last_order_date are calculated but never surfaced in the final output. If they aren’t needed, remove the logic. If they are useful (which they likely are), include them in the SELECT.

5. Full Name vs Separate Names

- It’s good that full_name is constructed, but we might want to also retain first_name and last_name for BI flexibility and easier downstream filtering/grouping.

6. Customer Type Logic

- The customer_type logic is reasonable, but business logic like "premium > $500" is subjective and could shift. Consider moving this to a dedicated dim_customer or customer_segmentation model with clearer business rule documentation.
